### PR TITLE
fix: close three critical auth/logging gaps in recipe API

### DIFF
--- a/jump-to-recipe/plans/codebase-audit-plan.md
+++ b/jump-to-recipe/plans/codebase-audit-plan.md
@@ -1,0 +1,83 @@
+# Codebase Audit & Remediation Plan
+
+_Generated 2026-06-15. Tracks findings from a security/fragility/consistency review of jump-to-recipe._
+
+Status legend: ⬜ todo · 🟦 doing · ✅ done
+
+Effort: **S** (minutes) · **M** (hours) · **L** (multi-session refactor) · 🟢 quick win
+
+---
+
+## 🔴 Critical — fix before next deploy
+
+### ✅ 1. `POST /api/recipes` has no authentication — Effort S
+`src/app/api/recipes/route.ts:230`
+- POST handler never calls `getServerSession`. Comment says "handled on client side" (not enforcement).
+- `authorId` comes from the request body and is inserted directly → unauthenticated users can create recipes AND forge `authorId` as any user.
+- PUT/DELETE on the same resource already check session + ownership correctly.
+- **Fix:** require session, override `authorId = session.user.id` server-side (ignore body value).
+
+### ✅ 2. Middleware skips auth for ALL of `/api/recipes/*`, every method — Effort S
+`src/middleware.ts:19-28`
+- `publicApiRoutes` uses `startsWith('/api/recipes')` with no method check → matches POST/PUT/DELETE and every subroute.
+- Middleware also does not protect any API route except `/admin` (allow-by-default for APIs).
+- **Fix:** gate the `/api/recipes` public entry on `req.method === 'GET'`.
+
+### ⬜ 3. Unauthenticated SSRF in recipe import — Effort M
+`src/app/api/recipes/import/route.ts:9`
+- Takes user-supplied `url`, does `fetch(url)` server-side, no auth, no host validation beyond `new URL()`.
+- Can hit internal services / cloud metadata (169.254.169.254, localhost) and return response to caller.
+- **Fix:** require auth; block private/link-local IPs + non-http(s) schemes; consider allowlist.
+
+### ✅ 4. Credentials logged in plaintext on every login — Effort S 🟢
+`src/lib/auth.ts:30-53`
+- `console.log` of `credentials.email` (PII) and password-match outcome on every login.
+- 22 non-test files contain `console.log`; API routes dump full request bodies (`import/route.ts:16`, `recipes/route.ts:236-241`).
+- **Fix:** delete credential logs now; strip/route the rest through a leveled logger later.
+
+---
+
+## 🟠 Soon — within next sprint
+
+### ⬜ 5. Protected-route middleware only checks cookie presence, not validity — Effort M
+`src/middleware.ts:88-100` — any non-empty cookie passes. Admin branch uses `getToken()`; page branch should too.
+
+### ⬜ 6. Visibility-filter SQL duplicated across 4 routes — Effort M
+`recipes/route.ts`, `recipes/[id]/route.ts`, `recipes/search/route.ts`, `recipes/discover/route.ts`.
+Extract `buildVisibilityCondition(userId, isAdmin)` into `src/lib/recipe-permissions.ts`.
+
+### ⬜ 7. No server-side rate limiting anywhere — Effort M
+Only client-side retry exists. Import + auth endpoints need throttling (SSRF/DoS vector).
+
+### ⬜ 8. `MIGRATION_AUTH_TOKEN` shared secret outside validated env schema — Effort S
+`migration/recipes/route.ts:19`. Add to `src/lib/env.ts` Zod schema; consider gating migration routes to non-prod or removing post-migration.
+
+### ⬜ 9. `updateData: any` defeats validated types — Effort S 🟢
+`recipes/[id]/route.ts:300`. Type as `Partial<typeof recipes.$inferInsert>`. Broader: 60 `: any` + 30 `as any` in non-test code; give JSONB columns real shared types in `src/types/recipe.ts`.
+
+---
+
+## 🟡 Later — opportunistic tech debt
+
+### ⬜ 10. CLAUDE.md documents non-existent `src/server/actions/` — Effort S 🟢
+No `src/server/` dir exists. Reconcile doc with reality.
+
+### ⬜ 11. Leftover dead route dirs — Effort S 🟢
+Empty `src/app/api/test-endpoint/`; stray `src/app/api/uploadthing/page.tsx` (uploadthing not a dep); `src/app/demo/page.tsx` with console.logs. Delete (confirm first).
+
+### ⬜ 12. Files far over the 200-line convention — Effort L
+`recipe-form.tsx` (1124), `recipe-ingredients-with-sections.tsx` (1102), `import/route.ts` (1050), `recipe-editor.tsx` (777). Highest-value split: `import/route.ts`.
+
+### ⬜ 13. Inconsistent error-response shapes — Effort M
+Mix of `{error}` / `{error,message}` / `{error,details}`; `[id]/route.ts:336-355` string-sniffs `error.message` to pick status. Standardize on `error-handling.ts`/`api-utils.ts`.
+
+### ⬜ 14. Inconsistent indentation/style — Effort S
+`recipes/route.ts` is 4-space; rest 2-space. Builds ignore lint. Run `npm run format`.
+
+---
+
+## Quick-win shortlist
+1. #4 — delete credential logs (security)
+2. #1 — session check + server-set authorId (security)
+3. #9 — type `updateData`
+4. #10 / #11 — fix CLAUDE.md claim, remove dead dirs

--- a/jump-to-recipe/src/app/api/recipes/route.ts
+++ b/jump-to-recipe/src/app/api/recipes/route.ts
@@ -218,7 +218,8 @@ export async function GET(req: NextRequest) {
  * POST /api/recipes
  * 
  * Creates a new recipe with strict validation
- * Requires authentication (handled on client side)
+ * Requires authentication - the recipe author is taken from the session,
+ * never from the request body
  * Enforces unique IDs and resolves position conflicts
  * 
  * Position Validation (Requirement 7.1):
@@ -229,8 +230,23 @@ export async function GET(req: NextRequest) {
  */
 export async function POST(req: NextRequest) {
     try {
+        // Require authentication - only logged-in users can create recipes
+        const session = await getServerSession(authOptions);
+        if (!session?.user?.id) {
+            return NextResponse.json(
+                {
+                    error: 'Authentication required',
+                    message: 'You must be logged in to create a recipe.',
+                },
+                { status: 401 }
+            );
+        }
+
         // Parse request body
         const body = await req.json();
+
+        // Author is always the authenticated user - never trust a client-supplied authorId
+        body.authorId = session.user.id;
 
         // Log the incoming data for debugging
         console.log('📝 Received recipe data for creation:');

--- a/jump-to-recipe/src/lib/auth.ts
+++ b/jump-to-recipe/src/lib/auth.ts
@@ -27,10 +27,7 @@ export const authOptions: AuthOptions = {
         password: { label: "Password", type: "password" }
       },
       async authorize(credentials) {
-        console.log('Authorize function called with credentials:', credentials?.email);
-
         if (!credentials?.email || !credentials?.password) {
-          console.log('Missing email or password');
           return null;
         }
 
@@ -40,17 +37,13 @@ export const authOptions: AuthOptions = {
             where: eq(users.email, credentials.email),
           });
 
-          console.log('User found:', user ? 'Yes' : 'No');
-
           // If no user or no password (OAuth user), return null
           if (!user || !user.password) {
-            console.log('No user or no password');
             return null;
           }
 
           // Compare passwords
           const passwordMatch = await bcrypt.compare(credentials.password, user.password);
-          console.log('Password match:', passwordMatch ? 'Yes' : 'No');
 
           if (!passwordMatch) {
             return null;

--- a/jump-to-recipe/src/middleware.ts
+++ b/jump-to-recipe/src/middleware.ts
@@ -15,15 +15,20 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // API routes that don't require authentication
+  // API routes that don't require authentication regardless of method
   const publicApiRoutes = [
     '/api/auth',
     '/api/recipes/search',
     '/api/recipes/discover',
-    '/api/recipes' // Allow GET requests to browse public recipes
   ];
 
   if (publicApiRoutes.some(route => pathname.startsWith(route))) {
+    return NextResponse.next();
+  }
+
+  // Public recipe browsing: only GET requests to /api/recipes are public.
+  // Mutations (POST/PUT/DELETE) must be authenticated by their route handlers.
+  if (pathname.startsWith('/api/recipes') && request.method === 'GET') {
     return NextResponse.next();
   }
 


### PR DESCRIPTION
## Summary

Addresses the three **critical** findings from the codebase audit (tracked in `plans/codebase-audit-plan.md`). These are defense-in-depth layers that work together — #1 is the real enforcement; #2 closes the middleware gap that let mutations through unchecked.

### 1. `POST /api/recipes` had no authentication
The handler never checked the session and inserted a client-supplied `authorId` directly. Unauthenticated users could create recipes and forge ownership as any user. Now returns 401 without a session and always sets `authorId` from `session.user.id`, ignoring the body value. (PUT/DELETE on the same resource already did this correctly.)

### 2. Middleware exempted all of `/api/recipes/*` from auth
`publicApiRoutes` used `startsWith('/api/recipes')` with no method check, so POST/PUT/DELETE and every subroute bypassed middleware. Now the public exemption is **GET only**; mutations fall through to their handlers' auth checks. `/api/auth`, `/api/recipes/search`, and `/api/recipes/discover` remain public for all methods as before.

### 3. Credentials logged in plaintext on every login
Removed `console.log` calls in the credentials `authorize()` flow that leaked user emails (PII) and password-match outcomes to server logs. The catch-block `console.error` is retained.

## Verification
- `npm run type-check`: no errors in the three edited files (pre-existing failures in `src/lib/__tests__/*` fixtures are unrelated to this change).
- `npx eslint` passes clean on all three files.

## Follow-ups (tracked, not in this PR)
- **Critical #3:** unauthenticated SSRF in `/api/recipes/import` (server-side `fetch` of arbitrary URLs).
- See `plans/codebase-audit-plan.md` for the full backlog (items 5–14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)