### PR TITLE
Security audit phase 5 — config hardening (partial)

### DIFF
--- a/jump-to-recipe/next.config.ts
+++ b/jump-to-recipe/next.config.ts
@@ -118,6 +118,23 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  // Baseline security headers (transport-agnostic, safe over HTTP).
+  // Deferred until HTTPS is set up: Strict-Transport-Security (HSTS).
+  // Deferred to a dedicated effort: Content-Security-Policy (needs nonce
+  // handling for Next.js inline scripts to enforce without breaking hydration).
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/jump-to-recipe/plans/security-audit-plan.md
+++ b/jump-to-recipe/plans/security-audit-plan.md
@@ -192,16 +192,29 @@ Files: `src/lib/rate-limit.ts` (new), `src/app/api/auth/register/route.ts`,
 
 ## Phase 5 — Config hardening
 
-**Priority: Low. Effort: ~1 hr.**
+**Priority: Low. Status: PARTIAL** (branch `security/phase5-config-hardening`).
 
-- [ ] Make `NEXTAUTH_URL` required in production (`src/lib/env.ts:13`) to remove the
-      host-header-injection surface from NextAuth callback derivation.
-- [ ] Add a `headers()` block in `next.config.ts`: CSP, HSTS,
-      `X-Content-Type-Options: nosniff`, `X-Frame-Options`/frame-ancestors.
-- [ ] Tighten `remotePatterns` wildcards (`*.amazonaws.com`, `*.cloudfront.net`,
-      `*.wp.com`) if specific hosts can be enumerated.
-- [ ] Enforce `npm run type-check` + `npm run lint` in CI so security regressions
-      aren't hidden by `ignoreBuildErrors`/`ignoreDuringBuilds` in production builds.
+- [x] Make `NEXTAUTH_URL` required in production (`src/lib/env.ts`) to remove the
+      host-header-injection surface from NextAuth callback derivation. Implemented via
+      `superRefine`: errors when `NODE_ENV==='production'` and unset, but skips the
+      Next build phase (`NEXT_PHASE==='phase-production-build'`) so builds don't fail.
+      **Deploy note:** the prod runtime env MUST set `NEXTAUTH_URL` or the app will
+      refuse to boot.
+- [x] Added a `headers()` block in `next.config.ts` with baseline headers, verified
+      live via the dev server: `X-Content-Type-Options: nosniff`,
+      `X-Frame-Options: SAMEORIGIN`, `Referrer-Policy: strict-origin-when-cross-origin`,
+      `Permissions-Policy: camera=(), microphone=(), geolocation=()`.
+- [ ] **Deferred — HSTS.** Add `Strict-Transport-Security` once HTTPS is set up
+      (browsers ignore it over HTTP, and setting it prematurely risks lockout when
+      HTTPS lands). One-liner to add to the headers block at that point.
+- [ ] **Deferred — CSP.** Needs nonce handling for Next.js inline scripts to enforce
+      without breaking hydration; do as a dedicated effort (consider Report-Only first).
+- [ ] **Deferred — tighten `remotePatterns`** (`*.amazonaws.com`, `*.cloudfront.net`,
+      `*.wp.com`). The S3 host is env-dependent (`${AWS_S3_BUCKET}.s3.${region}.amazonaws.com`)
+      and recipe images come from varied CDNs; low value / real breakage risk for now.
+- [ ] **Deferred — CI enforcement** of `type-check` + `lint`. No CI exists yet and there
+      are pre-existing type/lint errors; owner is not setting up CI right now. Revisit as
+      a separate cleanup that fixes the existing errors first.
 
 ---
 

--- a/jump-to-recipe/src/lib/env.ts
+++ b/jump-to-recipe/src/lib/env.ts
@@ -12,14 +12,26 @@ const envSchema = z.object({
   // Auth
   NEXTAUTH_URL: z.string().min(1).optional(),
   NEXTAUTH_SECRET: z.string().min(1),
-  
+
   // OAuth Providers
   GOOGLE_ID: z.string().min(1),
   GOOGLE_SECRET: z.string().min(1),
-  
+
   // File Storage
   MAX_RECIPE_PHOTO_SIZE_MB: z.string().regex(/^\d+$/).default('10').transform(Number),
   MAX_RECIPE_PHOTO_COUNT: z.string().regex(/^\d+$/).default('10').transform(Number),
+}).superRefine((data, ctx) => {
+  // Require NEXTAUTH_URL at runtime in production so NextAuth does not derive
+  // the callback host from a (spoofable) Host header. Skip during the Next.js
+  // build phase, where runtime env vars are not yet present.
+  const isBuildPhase = process.env.NEXT_PHASE === 'phase-production-build';
+  if (data.NODE_ENV === 'production' && !isBuildPhase && !data.NEXTAUTH_URL) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['NEXTAUTH_URL'],
+      message: 'NEXTAUTH_URL is required in production',
+    });
+  }
 });
 
 // Parse and validate environment variables


### PR DESCRIPTION
## Summary

Phase 5 of the security audit (`plans/security-audit-plan.md`) — defense-in-depth config hardening. Ships the two clearly-worth-it, low-risk items; the finicky/higher-risk items are intentionally deferred with rationale.

## What's included

**Require `NEXTAUTH_URL` in production** (`src/lib/env.ts`)
- Prevents NextAuth from deriving its callback host from a spoofable `Host` header.
- Enforced at runtime when `NODE_ENV=production` via a `superRefine`; skips the Next build phase (`NEXT_PHASE==='phase-production-build'`) so production builds don't fail on a runtime-only env var.

**Baseline security response headers** (`next.config.ts` `headers()`)
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: SAMEORIGIN`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Permissions-Policy: camera=(), microphone=(), geolocation=()`
- Verified live via the dev server (all four headers emit on `/`).

## ⚠️ Deploy note
Once this is live, the **production runtime env must set `NEXTAUTH_URL`** or the app will refuse to boot. Confirm it's in the deployment config before deploying.

## Deferred (with rationale)
- **HSTS** — HTTPS isn't set up yet; browsers ignore HSTS over HTTP and setting it early risks lockout. One-line add once HTTPS lands.
- **CSP** — needs nonce handling for Next.js inline scripts to enforce without breaking hydration; better as a dedicated effort (Report-Only first).
- **Tighten `remotePatterns`** (`*.amazonaws.com`, etc.) — the S3 host is env-dependent and recipe images come from varied CDNs; low value / real breakage risk for now.
- **CI enforcement** of type-check + lint — no CI exists yet and there are pre-existing type/lint errors; deferred by owner.

## Tests / verification
- `type-check` and `lint` clean on changed files.
- Headers confirmed at runtime; no HSTS/CSP emitted (as intended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)