### PR TITLE
feat: allow fraction input for ingredient quantities

### DIFF
--- a/jump-to-recipe/plans/fraction-ingredient-quantities-plan.md
+++ b/jump-to-recipe/plans/fraction-ingredient-quantities-plan.md
@@ -1,0 +1,69 @@
+# Fraction-based ingredient quantities
+
+## Context
+
+Ingredient quantities can currently only be entered as decimals — the amount field in the ingredient form is a plain `type="number"` input. Recipes are naturally written with fractions ("½ tsp", "1¾ cups"), so users have to mentally convert to decimal to enter a recipe, which is unnatural and error-prone (especially for the non-technical family members this app is built for).
+
+The data model already anticipates this: `Ingredient` (`src/types/recipe.ts:14-22`) has both `amount: number` (canonical decimal, used for math/scaling) and an optional `displayAmount?: string` (pre-formatted text shown instead of the decimal when present). The import-from-URL pipeline already populates both fields when scraping recipes that contain fraction text. What's missing is a way for a user to type a fraction directly into the manual add/edit ingredient form — that path only accepts decimals today.
+
+Goal: let users type quantities like `1/2`, `1 3/4`, or `2` into the ingredient form and have them save/display correctly, while keeping `amount` as the decimal used everywhere else (scaling, math), matching the existing architecture.
+
+Per discussion with the user:
+- Store `amount` as the parsed decimal (existing pattern), `displayAmount` as the fraction text — no schema change needed.
+- Input is a single plain text field, parsed on save (blur), not separate whole/fraction pickers.
+- Only new/edited ingredients get fraction support — no backfill of existing decimal-only recipes.
+- Also fix a related bug in grocery list scaling (found during investigation) that mishandles fraction `displayAmount` text.
+
+## Existing pieces being reused
+
+- `src/lib/fraction-utils.ts` — `formatFractionForDisplay`, `fractionToDecimal`, `decimalToFraction`. Already used by `src/lib/recipe-scaling.ts` for the ½×/1×/2× display scaling feature (PR #86).
+- `Ingredient.displayAmount` (`src/types/recipe.ts:19`) and `ingredientSchema.displayAmount` (`src/lib/validations/recipe.ts:13`, unvalidated optional string) — already plumbed through display code:
+  - `recipe-display.tsx:222-236, 256-270` — `{scaled.displayAmount || scaled.amount} {scaled.unit}`
+  - `recipe-editor.tsx:567-576` — same fallback pattern
+  - `grocery-list-display.tsx:85-90` — same fallback pattern
+  No display-side changes needed — this plan only touches how the value gets *into* `displayAmount`/`amount` from manual entry.
+- `setError`/`clearErrors` props already flow into `RecipeIngredientsWithSections` (`recipe-ingredients-with-sections.tsx:53-54`) and are already used for manual field-level errors elsewhere in that file — reuse the same pattern for quantity parse errors.
+
+## Implementation
+
+### 1. `src/lib/fraction-utils.ts` — add a single parse entry point, fix a bug
+
+Add `parseQuantityInput(input: string): { amount: number; displayAmount: string } | null`:
+- Empty/whitespace-only → `{ amount: 0, displayAmount: '' }`.
+- Contains `/` → treat as fraction syntax. Support `W N/D` (mixed) and `N/D` (simple), any positive integer denominator (not just the fixed halves/quarters/eighths set). Compute `amount` by division. Compute `displayAmount` via `formatFractionForDisplay` (unicode glyph when the fraction is one of the recognized ones, otherwise keep the typed `W N/D` / `N/D` text as-is).
+- Otherwise → parse as a plain number (`parseFloat`). `displayAmount` = the trimmed input as typed (no forced conversion to a fraction glyph — a user who types `1.5` keeps seeing `1.5`, not `1½`, so behavior for existing decimal users is unchanged).
+- Reject (return `null`): non-numeric garbage, negative numbers, zero/invalid denominator. This drives a validation error in the form.
+
+Fix existing bug while touching this file: `fractionToDecimal`'s mixed-number branch (`fraction-utils.ts:46-51`) looks up the fractional part *only* in the fixed `fractionMap`, so `"1 2/5"` silently computes as `1 + 0 = 1` (the `2/5` is dropped because it's not a recognized denominator). Confirmed via grep that `fractionToDecimal` has no other callers in the live app, so it's safe to fix in place — the mixed-number branch will compute the fractional part generically (`numerator/denominator`) instead of relying on the map lookup.
+
+Add unit tests in `src/lib/__tests__/fraction-utils.test.ts` (new file) covering: whole numbers, simple fractions, mixed fractions (including uncommon denominators like `2/5`), decimals, empty input, and invalid input.
+
+### 2. `src/components/recipes/recipe-ingredients-with-sections.tsx` — quantity input
+
+Two near-identical ingredient rows need the same change: the sectioned row (`~729-753`, field `${fieldBaseName}.amount`) and the flat row (`~899-920`, field `ingredients.${index}.amount`).
+
+For each:
+- Change the visible `Input` from `type="number"` bound to `.amount` → `type="text"` bound to `.displayAmount`, placeholder e.g. `"e.g. 1 3/4"`.
+- `onChange`: pass the raw typed text straight through to the `displayAmount` field.
+- `onBlur`: run `parseQuantityInput(value)`.
+  - Valid → `setValue(`${base}.amount`, result.amount)`, `setValue(`${base}.displayAmount`, result.displayAmount)`, `clearErrors(`${base}.amount`)`.
+  - Invalid (`null`) → `setError(`${base}.amount`, { message: 'Enter a number or fraction, like 1/2 or 1 3/4' })`, leave the typed text in place, don't touch `amount`.
+- Add `setValue: UseFormSetValue<any>` to `RecipeIngredientsWithSectionsProps` and thread it from `recipe-form.tsx` and `recipe-editor.tsx` (the two call sites), same pattern as existing `setError`/`clearErrors` props.
+- `FormMessage` under the field already renders react-hook-form field errors.
+
+No Zod schema change needed — `ingredientSchema.amount` stays `z.number().nonnegative()`, `displayAmount` stays an unvalidated optional string.
+
+### 3. `src/lib/grocery-list-generator.ts` — fix scaling bug
+
+`scaleIngredient` (lines 123-137) does `parseFloat(ingredient.displayAmount) * scaleFactor` when `displayAmount` is set. For a unicode fraction like `"½"` this returns `NaN`; for `"1½"` it truncates to `1`. Fix: scale from `ingredient.amount` (already correct) and format the result via `decimalToFraction`/`roundToNiceFraction` (reuse from `recipe-scaling.ts`) instead of re-parsing `displayAmount` text.
+
+## Verification
+
+- `npm run type-check` and `npm run lint`.
+- `npx jest src/lib/__tests__/fraction-utils.test.ts`.
+- Manual, via dev server + browser:
+  1. Create a recipe, enter ingredient quantities as `1/2`, `1 3/4`, `2/5` (uncommon denominator), and a plain decimal `1.5` — confirm each saves and redisplays correctly on the recipe detail page.
+  2. Edit an existing ingredient's quantity from decimal to a fraction and back — confirm round-trip.
+  3. Type garbage (`"abc"`) into the quantity field, blur, confirm a validation error appears and blocks save.
+  4. Use the ½×/1×/2× scaler on a recipe with fraction-entered ingredients — confirm scaled amounts look correct.
+  5. Add a fraction-quantity recipe to a grocery list and adjust servings — confirm the generated grocery list quantity is correct.

--- a/jump-to-recipe/src/components/recipes/__tests__/recipe-ingredients-with-sections.test.tsx
+++ b/jump-to-recipe/src/components/recipes/__tests__/recipe-ingredients-with-sections.test.tsx
@@ -14,10 +14,10 @@ jest.mock('../../sections/section-manager', () => ({
 }));
 
 // Simple test wrapper
-function TestWrapper({ 
+function TestWrapper({
   defaultIngredients = [{ id: '1', name: 'Test Ingredient', amount: 1, unit: 'cup', notes: '', position: 0 }],
-  defaultSections = []
-}: { 
+  defaultSections = [],
+}: {
   defaultIngredients?: any[];
   defaultSections?: any[];
 }) {
@@ -27,15 +27,18 @@ function TestWrapper({
       ingredientSections: defaultSections,
     },
   });
+  const watchedAmount = form.watch('ingredients.0.amount');
 
   return (
     <FormProvider {...form}>
+      <div data-testid="debug-amount">{watchedAmount}</div>
       <RecipeIngredientsWithSections
         control={form.control}
         watch={form.watch}
         errors={form.formState.errors}
         setError={form.setError}
         clearErrors={form.clearErrors}
+        setValue={form.setValue}
       />
     </FormProvider>
   );
@@ -98,13 +101,51 @@ describe('RecipeIngredientsWithSections', () => {
     render(<TestWrapper />);
     
     expect(screen.getByPlaceholderText('Ingredient name')).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('Quantity')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('e.g. 1 3/4')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Notes (optional)')).toBeInTheDocument();
   });
 
   it('renders add ingredient button in flat mode', () => {
     render(<TestWrapper />);
-    
+
     expect(screen.getByText('Add Ingredient')).toBeInTheDocument();
+  });
+
+  it('falls back to displaying the decimal amount for legacy ingredients with no displayAmount', () => {
+    render(<TestWrapper defaultIngredients={[
+      { id: '1', name: 'Sugar', amount: 1.5, unit: 'cup', notes: '', position: 0 },
+    ]} />);
+
+    expect(screen.getByDisplayValue('1.5')).toBeInTheDocument();
+  });
+
+  it('parses a typed mixed fraction into amount and displayAmount on blur', async () => {
+    const user = userEvent.setup();
+    render(<TestWrapper defaultIngredients={[
+      { id: '1', name: 'Flour', amount: 0, unit: 'cup', displayAmount: '', notes: '', position: 0 },
+    ]} />);
+
+    const quantityInput = screen.getByPlaceholderText('e.g. 1 3/4');
+    await user.clear(quantityInput);
+    await user.type(quantityInput, '1 3/4');
+    await user.tab();
+
+    expect(quantityInput).toHaveValue('1¾');
+    expect(screen.getByTestId('debug-amount')).toHaveTextContent('1.75');
+    expect(screen.queryByText(/enter a number or fraction/i)).not.toBeInTheDocument();
+  });
+
+  it('shows a validation error for unparseable quantity input', async () => {
+    const user = userEvent.setup();
+    render(<TestWrapper defaultIngredients={[
+      { id: '1', name: 'Flour', amount: 1, unit: 'cup', displayAmount: '1', notes: '', position: 0 },
+    ]} />);
+
+    const quantityInput = screen.getByPlaceholderText('e.g. 1 3/4');
+    await user.clear(quantityInput);
+    await user.type(quantityInput, 'abc');
+    await user.tab();
+
+    expect(await screen.findByText(/enter a number or fraction/i)).toBeInTheDocument();
   });
 });

--- a/jump-to-recipe/src/components/recipes/recipe-editor.tsx
+++ b/jump-to-recipe/src/components/recipes/recipe-editor.tsx
@@ -534,6 +534,7 @@ export function RecipeEditor({
                   errors={form.formState.errors}
                   setError={form.setError}
                   clearErrors={form.clearErrors}
+                  setValue={form.setValue}
                   isLoading={isLoading}
                 />
                 <div className="flex gap-2">

--- a/jump-to-recipe/src/components/recipes/recipe-form.tsx
+++ b/jump-to-recipe/src/components/recipes/recipe-form.tsx
@@ -727,6 +727,7 @@ export function RecipeForm({
           errors={form.formState.errors as any}
           setError={form.setError as any}
           clearErrors={form.clearErrors as any}
+          setValue={form.setValue as any}
           isLoading={isLoading}
           validationErrors={validationErrors}
           onValidate={handleValidation}

--- a/jump-to-recipe/src/components/recipes/recipe-ingredients-with-sections.tsx
+++ b/jump-to-recipe/src/components/recipes/recipe-ingredients-with-sections.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
-import { useFieldArray, Control, UseFormWatch, FieldErrors, UseFormSetError, UseFormClearErrors } from 'react-hook-form';
+import { useFieldArray, Control, UseFormWatch, FieldErrors, UseFormSetError, UseFormClearErrors, UseFormSetValue } from 'react-hook-form';
 import { Plus } from 'lucide-react';
 import { v4 as uuidv4 } from 'uuid';
 import { DragDropContext, Droppable, Draggable, DropResult, DragStart } from '@hello-pangea/dnd';
@@ -30,6 +30,7 @@ import type { Ingredient } from '@/types/recipe';
 import type { IngredientSection } from '@/types/sections';
 import { validateSectionName } from '@/lib/validations/recipe';
 import { reorderWithinSection, moveBetweenSections, getNextPosition } from '@/lib/section-position-utils';
+import { parseQuantityInput } from '@/lib/fraction-utils';
 import {
   SnapshotManager,
   validateDragDestination,
@@ -52,6 +53,7 @@ interface RecipeIngredientsWithSectionsProps {
   errors?: FieldErrors<any>;
   setError?: UseFormSetError<any>;
   clearErrors?: UseFormClearErrors<any>;
+  setValue?: UseFormSetValue<any>;
   isLoading?: boolean;
   validationErrors?: Map<string, string>;
   onValidate?: () => void;
@@ -64,6 +66,7 @@ export function RecipeIngredientsWithSections({
   errors,
   setError,
   clearErrors,
+  setValue,
   isLoading = false,
   validationErrors,
   onValidate,
@@ -728,28 +731,41 @@ export function RecipeIngredientsWithSections({
               {/* Field order: Quantity, Unit, Ingredient Name, Notes */}
               <FormField
                 control={control}
-                name={`${fieldBaseName}.amount`}
-                render={({ field }) => (
+                name={`${fieldBaseName}.displayAmount`}
+                render={({ field }) => {
+                  // Legacy ingredients may only have a decimal `amount` with no
+                  // `displayAmount` yet — fall back to it so the field isn't blank.
+                  const fallbackAmount = watch(`${fieldBaseName}.amount`);
+                  const displayValue = field.value || (fallbackAmount ? String(fallbackAmount) : '');
+                  return (
                   <FormItem>
                     <FormControl>
                       <Input
-                        type="number"
-                        step="0.1"
-                        placeholder="Quantity"
-                        {...field}
-                        onChange={(e) => {
-                          const value = e.target.value ? parseFloat(e.target.value) : 0;
-                          field.onChange(value);
-                          // Clear error if value becomes valid
-                          if (value >= 0 && clearErrors) {
-                            clearErrors(`${fieldBaseName}.amount`);
+                        type="text"
+                        placeholder="e.g. 1 3/4"
+                        name={field.name}
+                        ref={field.ref}
+                        value={displayValue}
+                        onChange={(e) => field.onChange(e.target.value)}
+                        onBlur={(e) => {
+                          field.onBlur();
+                          const parsed = parseQuantityInput(e.target.value);
+                          if (parsed) {
+                            setValue?.(`${fieldBaseName}.amount`, parsed.amount);
+                            setValue?.(`${fieldBaseName}.displayAmount`, parsed.displayAmount);
+                            clearErrors?.(`${fieldBaseName}.displayAmount`);
+                          } else {
+                            setError?.(`${fieldBaseName}.displayAmount`, {
+                              message: 'Enter a number or fraction, like 1/2 or 1 3/4',
+                            });
                           }
                         }}
                       />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
-                )}
+                  );
+                }}
               />
 
               <FormField
@@ -898,25 +914,41 @@ export function RecipeIngredientsWithSections({
                       {/* Field order: Quantity, Unit, Ingredient Name, Notes */}
                       <FormField
                         control={control}
-                        name={`ingredients.${index}.amount`}
-                        render={({ field }) => (
+                        name={`ingredients.${index}.displayAmount`}
+                        render={({ field }) => {
+                          // Legacy ingredients may only have a decimal `amount` with no
+                          // `displayAmount` yet — fall back to it so the field isn't blank.
+                          const fallbackAmount = watch(`ingredients.${index}.amount`);
+                          const displayValue = field.value || (fallbackAmount ? String(fallbackAmount) : '');
+                          return (
                           <FormItem>
                             <FormControl>
                               <Input
-                                type="number"
-                                step="0.1"
-                                placeholder="Quantity"
-                                {...field}
-                                onChange={(e) =>
-                                  field.onChange(
-                                    e.target.value ? parseFloat(e.target.value) : 0
-                                  )
-                                }
+                                type="text"
+                                placeholder="e.g. 1 3/4"
+                                name={field.name}
+                                ref={field.ref}
+                                value={displayValue}
+                                onChange={(e) => field.onChange(e.target.value)}
+                                onBlur={(e) => {
+                                  field.onBlur();
+                                  const parsed = parseQuantityInput(e.target.value);
+                                  if (parsed) {
+                                    setValue?.(`ingredients.${index}.amount`, parsed.amount);
+                                    setValue?.(`ingredients.${index}.displayAmount`, parsed.displayAmount);
+                                    clearErrors?.(`ingredients.${index}.displayAmount`);
+                                  } else {
+                                    setError?.(`ingredients.${index}.displayAmount`, {
+                                      message: 'Enter a number or fraction, like 1/2 or 1 3/4',
+                                    });
+                                  }
+                                }}
                               />
                             </FormControl>
                             <FormMessage />
                           </FormItem>
-                        )}
+                          );
+                        }}
                       />
 
                       <FormField

--- a/jump-to-recipe/src/lib/__tests__/fraction-utils.test.ts
+++ b/jump-to-recipe/src/lib/__tests__/fraction-utils.test.ts
@@ -1,0 +1,56 @@
+import { fractionToDecimal, parseQuantityInput } from '../fraction-utils';
+
+describe('fractionToDecimal', () => {
+  it('handles mixed numbers with uncommon denominators', () => {
+    expect(fractionToDecimal('1 2/5')).toBeCloseTo(1.4);
+  });
+
+  it('handles mixed numbers with common denominators', () => {
+    expect(fractionToDecimal('1 3/4')).toBeCloseTo(1.75);
+  });
+});
+
+describe('parseQuantityInput', () => {
+  it('parses whole numbers', () => {
+    expect(parseQuantityInput('2')).toEqual({ amount: 2, displayAmount: '2' });
+  });
+
+  it('parses decimals', () => {
+    expect(parseQuantityInput('1.5')).toEqual({ amount: 1.5, displayAmount: '1.5' });
+  });
+
+  it('parses simple fractions', () => {
+    const result = parseQuantityInput('1/2');
+    expect(result?.amount).toBeCloseTo(0.5);
+    expect(result?.displayAmount).toBe('½');
+  });
+
+  it('parses mixed fractions with common denominators as unicode', () => {
+    const result = parseQuantityInput('1 3/4');
+    expect(result?.amount).toBeCloseTo(1.75);
+    expect(result?.displayAmount).toBe('1¾');
+  });
+
+  it('parses mixed fractions with uncommon denominators', () => {
+    const result = parseQuantityInput('1 2/5');
+    expect(result?.amount).toBeCloseTo(1.4);
+    expect(result?.displayAmount).toBe('1 2/5');
+  });
+
+  it('treats empty input as a valid zero quantity', () => {
+    expect(parseQuantityInput('')).toEqual({ amount: 0, displayAmount: '' });
+    expect(parseQuantityInput('   ')).toEqual({ amount: 0, displayAmount: '' });
+  });
+
+  it('rejects non-numeric garbage', () => {
+    expect(parseQuantityInput('abc')).toBeNull();
+  });
+
+  it('rejects negative numbers', () => {
+    expect(parseQuantityInput('-1')).toBeNull();
+  });
+
+  it('rejects a zero denominator', () => {
+    expect(parseQuantityInput('1/0')).toBeNull();
+  });
+});

--- a/jump-to-recipe/src/lib/__tests__/grocery-list-generator.test.ts
+++ b/jump-to-recipe/src/lib/__tests__/grocery-list-generator.test.ts
@@ -1,0 +1,60 @@
+import { generateGroceryList } from '../grocery-list-generator';
+import type { Recipe } from '@/types/recipe';
+
+function makeRecipe(overrides: Partial<Recipe> = {}): Recipe {
+  return {
+    id: 'recipe-1',
+    title: 'Test Recipe',
+    description: null,
+    ingredients: [],
+    instructions: [],
+    prepTime: null,
+    cookTime: null,
+    servings: 2,
+    difficulty: null,
+    tags: [],
+    notes: null,
+    imageUrl: null,
+    sourceUrl: null,
+    authorId: null,
+    visibility: 'private',
+    commentsEnabled: true,
+    viewCount: 0,
+    likeCount: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe('generateGroceryList scaling', () => {
+  it('scales a unicode-fraction displayAmount from the decimal amount, not by re-parsing the fraction text', () => {
+    const recipe = makeRecipe({
+      servings: 2,
+      ingredients: [
+        { id: 'i1', name: 'flour', amount: 0.5, unit: 'cup', displayAmount: '½', position: 0 },
+      ],
+    });
+
+    const groceryList = generateGroceryList([recipe], { 'recipe-1': 4 });
+    const item = groceryList.find((i) => i.name === 'flour');
+
+    expect(item?.amount).toBeCloseTo(1);
+    expect(item?.displayAmount).toBe('1');
+  });
+
+  it('scales a mixed unicode-fraction displayAmount correctly instead of truncating it', () => {
+    const recipe = makeRecipe({
+      servings: 2,
+      ingredients: [
+        { id: 'i1', name: 'sugar', amount: 1.5, unit: 'cup', displayAmount: '1½', position: 0 },
+      ],
+    });
+
+    const groceryList = generateGroceryList([recipe], { 'recipe-1': 4 });
+    const item = groceryList.find((i) => i.name === 'sugar');
+
+    expect(item?.amount).toBeCloseTo(3);
+    expect(item?.displayAmount).toBe('3');
+  });
+});

--- a/jump-to-recipe/src/lib/fraction-utils.ts
+++ b/jump-to-recipe/src/lib/fraction-utils.ts
@@ -41,11 +41,18 @@ export function fractionToDecimal(input: string): number {
   };
   
   // Handle mixed numbers (e.g., "1½" or "1 1/2")
-  const mixedMatch = input.match(/^(\d+)[½¼¾⅓⅔⅛⅜⅝⅞]$/) || 
-                     input.match(/^(\d+)\s+(\d+\/\d+)$/);
+  const mixedMatch = input.match(/^(\d+)[½¼¾⅓⅔⅛⅜⅝⅞]$/) ||
+                     input.match(/^(\d+)\s+(\d+)\/(\d+)$/);
   if (mixedMatch) {
     const whole = parseInt(mixedMatch[1]);
-    const fractionPart = mixedMatch[2] || input.slice(mixedMatch[1].length);
+    if (mixedMatch[2] && mixedMatch[3]) {
+      // Generic "W N/D" — compute the fractional part directly so
+      // uncommon denominators (e.g. "1 2/5") aren't silently dropped.
+      const numerator = parseInt(mixedMatch[2]);
+      const denominator = parseInt(mixedMatch[3]);
+      return whole + numerator / denominator;
+    }
+    const fractionPart = input.slice(mixedMatch[1].length);
     const fractionValue = fractionMap[fractionPart] || 0;
     return whole + fractionValue;
   }
@@ -102,4 +109,49 @@ export function decimalToFraction(decimal: number): string {
   
   // Return decimal as string if no fraction match
   return decimal.toString();
+}
+
+// Parse free-text quantity input (e.g. "1 3/4", "1/2", "2", "1.5") entered by
+// a user into a canonical decimal amount plus a display string. Returns null
+// for input that can't be parsed as a non-negative quantity.
+export function parseQuantityInput(input: string): { amount: number; displayAmount: string } | null {
+  const trimmed = input.trim();
+
+  if (trimmed === '') {
+    return { amount: 0, displayAmount: '' };
+  }
+
+  const mixedMatch = trimmed.match(/^(\d+)\s+(\d+)\/(\d+)$/);
+  const simpleMatch = trimmed.match(/^(\d+)\/(\d+)$/);
+
+  if (mixedMatch || simpleMatch) {
+    const whole = mixedMatch ? parseInt(mixedMatch[1], 10) : 0;
+    const numerator = parseInt((mixedMatch ? mixedMatch[2] : simpleMatch![1]), 10);
+    const denominator = parseInt((mixedMatch ? mixedMatch[3] : simpleMatch![2]), 10);
+
+    if (denominator === 0) {
+      return null;
+    }
+
+    // Format only the fractional part so uncommon denominators (not in the
+    // unicode map) stay as "1 2/5" instead of concatenating into "12/5".
+    const fractionText = `${numerator}/${denominator}`;
+    const formattedFraction = formatFractionForDisplay(fractionText);
+    const isUnicodeGlyph = formattedFraction !== fractionText;
+    const displayAmount = whole === 0
+      ? formattedFraction
+      : isUnicodeGlyph
+        ? `${whole}${formattedFraction}`
+        : `${whole} ${formattedFraction}`;
+
+    return { amount: whole + numerator / denominator, displayAmount };
+  }
+
+  const plainNumberPattern = /^(\d+(\.\d+)?|\.\d+)$/;
+  if (!plainNumberPattern.test(trimmed)) {
+    return null;
+  }
+
+  const amount = parseFloat(trimmed);
+  return isNaN(amount) ? null : { amount, displayAmount: trimmed };
 }

--- a/jump-to-recipe/src/lib/grocery-list-generator.ts
+++ b/jump-to-recipe/src/lib/grocery-list-generator.ts
@@ -5,6 +5,7 @@ import {
   INGREDIENT_CATEGORIES
 } from '@/types/grocery-list';
 import { convertUnit } from './unit-conversion';
+import { formatAmountDisplay } from './recipe-scaling';
 
 /**
  * Categorizes an ingredient based on its name
@@ -126,13 +127,15 @@ function scaleIngredient(ingredient: Ingredient, originalServings: number, newSe
   }
   
   const scaleFactor = newServings / originalServings;
-  
+  const scaledAmount = ingredient.amount * scaleFactor;
+
   return {
     ...ingredient,
-    amount: ingredient.amount * scaleFactor,
-    displayAmount: ingredient.displayAmount 
-      ? `${(parseFloat(ingredient.displayAmount) * scaleFactor).toString()}` 
-      : undefined,
+    amount: scaledAmount,
+    // Recompute from the scaled decimal rather than re-parsing displayAmount
+    // text — that text can be a unicode fraction (e.g. "½"), which
+    // parseFloat silently mangles (NaN, or truncates "1½" to 1).
+    displayAmount: ingredient.displayAmount ? formatAmountDisplay(scaledAmount) : undefined,
   };
 }
 


### PR DESCRIPTION
## Summary
- Ingredient quantity fields now accept free-text fraction input (`1/2`, `1 3/4`, plain decimals like `1.5`), parsed on blur into the existing `amount`/`displayAmount` pair — no schema change needed.
- Fixes a mixed-number parsing bug where uncommon denominators (e.g. `1 2/5`) silently dropped the fractional part.
- Fixes a related bug in grocery list serving-size scaling that mishandled unicode-fraction `displayAmount` text (e.g. `parseFloat("½")` → `NaN`), now scaled from the canonical decimal `amount` instead.
- Legacy ingredients with only a decimal `amount` (no `displayAmount`) still display correctly via a fallback.
- Invalid quantity text shows a validation message ("Enter a number or fraction, like 1/2 or 1 3/4") without corrupting the stored amount.

Plan: `jump-to-recipe/plans/fraction-ingredient-quantities-plan.md`

## Test plan
- [x] `npm run type-check` / `npm run lint` — no new errors introduced
- [x] `npx jest src/lib/__tests__/fraction-utils.test.ts src/lib/__tests__/grocery-list-generator.test.ts src/components/recipes/__tests__/recipe-ingredients-with-sections.test.tsx` — all passing, including new integration tests simulating typing a fraction, blurring, and verifying both the displayed unicode fraction and the underlying decimal amount
- [x] Manually verified in the browser: typed `1/2`, `1 3/4`, and a plain decimal into the quantity field on a real recipe form and confirmed correct save/display

🤖 Generated with [Claude Code](https://claude.com/claude-code)