### PR TITLE
fix: surface login errors and normalize email casing

### DIFF
--- a/jump-to-recipe/src/app/api/auth/register/route.ts
+++ b/jump-to-recipe/src/app/api/auth/register/route.ts
@@ -44,9 +44,13 @@ export async function POST(request: NextRequest) {
 
     const validatedData = validationResult.data;
 
+    // Normalize email to lowercase so casing can't create duplicate accounts or
+    // cause phantom "invalid password" failures at sign in.
+    const email = validatedData.email.toLowerCase();
+
     // Throttle per email to blunt targeted abuse/enumeration.
     const emailLimit = checkRateLimit(
-      `register:email:${validatedData.email.toLowerCase()}`,
+      `register:email:${email}`,
       5,
       WINDOW_MS
     );
@@ -57,7 +61,7 @@ export async function POST(request: NextRequest) {
     // Check if user already exists. Return a generic message either way so the
     // response does not reveal whether an email is registered (enumeration).
     const existingUser = await db.query.users.findFirst({
-      where: (users, { eq }) => eq(users.email, validatedData.email),
+      where: (users, { eq }) => eq(users.email, email),
     });
 
     if (existingUser) {
@@ -73,7 +77,7 @@ export async function POST(request: NextRequest) {
     // Create user
     await db.insert(users).values({
       name: validatedData.name,
-      email: validatedData.email,
+      email,
       password: hashedPassword,
       role: 'user',
     });

--- a/jump-to-recipe/src/app/auth/login/page.tsx
+++ b/jump-to-recipe/src/app/auth/login/page.tsx
@@ -25,6 +25,7 @@ type LoginFormData = z.infer<typeof loginSchema>;
 function LoginForm() {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [oauthLoading, setOAuthLoading] = useState<boolean>(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const router = useRouter();
   const searchParams = useSearchParams();
   const callbackUrl = sanitizeCallbackUrl(searchParams.get('callbackUrl'));
@@ -52,22 +53,29 @@ function LoginForm() {
   
   const onSubmit = async (data: LoginFormData) => {
     setIsLoading(true);
+    setSubmitError(null);
     try {
       const result = await signIn('credentials', {
         redirect: false,
         email: data.email,
         password: data.password,
       });
-      
+
       if (result?.error) {
-        throw new Error(result.error);
+        setSubmitError(
+          result.error === 'CredentialsSignin'
+            ? 'Invalid email or password.'
+            : 'An error occurred during sign in. Please try again.'
+        );
+        return;
       }
-      
+
       if (result?.ok) {
         router.push(callbackUrl);
       }
     } catch (error) {
       console.error('Login error:', error);
+      setSubmitError('An unexpected error occurred. Please try again.');
     } finally {
       setIsLoading(false);
     }
@@ -81,10 +89,12 @@ function LoginForm() {
           <CardDescription>
             Sign in to your account to continue
           </CardDescription>
-          {error && (
+          {(submitError || error) && (
             <div className="rounded-md bg-red-50 p-4 mt-4">
               <div className="text-sm text-red-700">
-                {error === 'OAuthAccountNotLinked'
+                {submitError
+                  ? submitError
+                  : error === 'OAuthAccountNotLinked'
                   ? 'This email is already associated with another provider.'
                   : error === 'CredentialsSignin'
                   ? 'Invalid email or password.'

--- a/jump-to-recipe/src/lib/auth.ts
+++ b/jump-to-recipe/src/lib/auth.ts
@@ -46,9 +46,10 @@ export const authOptions: AuthOptions = {
         }
 
         try {
-          // Find user by email
+          // Find user by email. Normalize to lowercase so casing differences
+          // between sign-up and sign-in don't surface as "invalid password".
           const user = await db.query.users.findFirst({
-            where: eq(users.email, credentials.email),
+            where: eq(users.email, email),
           });
 
           // If no user or no password (OAuth user), return null


### PR DESCRIPTION
## Problem

Signing in with credentials produced **no visible feedback** — after submitting, nothing happened: no error, no success, no redirect.

The login form called `signIn('credentials', { redirect: false })` and threw any `result.error` into a `catch` block that only `console.error`'d it. So a rejected login (wrong password, rate-limited, or OAuth-only account) just reset the button with no message. The existing red error banner only read from URL search params, which are never populated when `redirect: false`.

## Changes

- **Surface login errors** (`src/app/auth/login/page.tsx`): added a `submitError` state, set on `result.error` (friendly "Invalid email or password." for `CredentialsSignin`) and in the `catch`; rendered in the existing red banner.
- **Normalize email casing**: `authorize()` now looks up the user by the already-lowercased email (`src/lib/auth.ts`); registration stores and de-dupes on a lowercased email (`src/app/api/auth/register/route.ts`). Prevents casing differences from surfacing as phantom "invalid password" failures or duplicate accounts.

## Notes

- **Existing accounts stored with uppercase emails** won't be found after this change, since lookups now lowercase the input. If there are such accounts in production, a one-off migration to lowercase `users.email` is needed — not included here.
- Rate-limited attempts still return the generic "Invalid email or password." by design (enumeration-safe), but now render instead of failing silently.

## Testing

- `npm run type-check` — no new errors in changed files (pre-existing failures exist only in unrelated recipe/section test files).
- `npx eslint` on the 3 changed files — 0 errors (3 pre-existing warnings from the commented-out Google OAuth block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)